### PR TITLE
Refactor Sequence hierarchy to close #60

### DIFF
--- a/development/DRAO-annotation.owl
+++ b/development/DRAO-annotation.owl
@@ -42,9 +42,6 @@
         <obo:IAO_0000115>An alternative term used by the ISA tools project (http://isa-tools.org).</obo:IAO_0000115>
         <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000118"/>
     </owl:AnnotationProperty>
-    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
-        <rdfs:label xml:lang="en">imported from</rdfs:label>
-    </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">definition</rdfs:label>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">textual definition</rdfs:label>
@@ -56,6 +53,9 @@
         <obo:IAO_0000115>A property representing the English language definitions of what NCI means by the concept. They may also include information about the definition&#39;s source and attribution in a form that can easily be interpreted by software.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official OBI definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
         <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
+    </owl:AnnotationProperty>
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
     </owl:AnnotationProperty>
     <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label">
         <rdfs:label>标签</rdfs:label>
@@ -784,18 +784,6 @@
     
 
 
-    <!-- http://edamontology.org/data_2044 -->
-
-    <owl:Class rdf:about="http://edamontology.org/data_2044">
-        <rdfs:label>Sequence</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://edamontology.org/data_0006"/>
-        <obo:IAO_0000118>Sequences</obo:IAO_0000118>
-        <obo:IAO_0000115>One or more molecular sequences, possibly with associated annotation.</obo:IAO_0000115>
-        <obo:IAO_0000412 rdf:resource="http://edamontology.org/EDAM.owl"/>
-    </owl:Class>
-    
-
-
     <!-- http://edamontology.org/data_2048 -->
 
     <owl:Class rdf:about="http://edamontology.org/data_2048">
@@ -1062,23 +1050,11 @@
     
 
 
-    <!-- http://edamontology.org/data_2976 -->
-
-    <owl:Class rdf:about="http://edamontology.org/data_2976">
-        <rdfs:label>Protein sequence</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://edamontology.org/data_2044"/>
-        <obo:IAO_0000115>One or more protein sequences, possibly with associated annotation.</obo:IAO_0000115>
-        <obo:IAO_0000118>Protein sequences</obo:IAO_0000118>
-        <obo:IAO_0000412 rdf:resource="http://edamontology.org/EDAM.owl"/>
-    </owl:Class>
-    
-
-
     <!-- http://edamontology.org/data_2977 -->
 
     <owl:Class rdf:about="http://edamontology.org/data_2977">
         <rdfs:label>Nucleic acid sequence</rdfs:label>
-        <rdfs:subClassOf rdf:resource="http://edamontology.org/data_2044"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001411"/>
         <obo:IAO_0000118>Nucleotide sequences</obo:IAO_0000118>
         <obo:IAO_0000118>DNA sequence</obo:IAO_0000118>
         <obo:IAO_0000118>Nucleic acid sequences</obo:IAO_0000118>
@@ -9444,7 +9420,7 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OGMS_0000123">
         <rdfs:label xml:lang="en">clinical data item</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
-        <obo:IAO_0000115>a data item that is about a patient and is the specified output of a health care process assay or diagnostic process</obo:IAO_0000115>
+        <obo:IAO_0000115>A data item that is about a patient and is the specified output of a health care process assay or diagnostic process</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ogms.owl"/>
     </owl:Class>
     
@@ -12241,34 +12217,34 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </rdf:Description>
     <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
     </rdf:Description>
     <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
     </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
     </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ogi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>

--- a/development/DRAO-fsannotation.owl
+++ b/development/DRAO-fsannotation.owl
@@ -175,9 +175,6 @@
     <rdf:Description rdf:about="http://edamontology.org/data_2042">
         <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
     </rdf:Description>
-    <rdf:Description rdf:about="http://edamontology.org/data_2044">
-        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
-    </rdf:Description>
     <rdf:Description rdf:about="http://edamontology.org/data_2048">
         <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
     </rdf:Description>
@@ -207,10 +204,6 @@
         <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
     </rdf:Description>
     <rdf:Description rdf:about="http://edamontology.org/data_2899">
-        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://edamontology.org/data_2976">
-        <domain:DRAO_0000001 xml:lang="en">Amino acid sequence</domain:DRAO_0000001>
         <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
     </rdf:Description>
     <rdf:Description rdf:about="http://edamontology.org/data_2977">
@@ -1841,6 +1834,10 @@
         <domain:DRAO_0000001 xml:lang="en">Pathway model</domain:DRAO_0000001>
         <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
     </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000001">
+        <domain:DRAO_0000001 xml:lang="en">Sequence</domain:DRAO_0000001>
+        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
+    </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000101">
         <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
         <domain:DRAO_0000001 xml:lang="en">Transposable element</domain:DRAO_0000001>
@@ -2008,6 +2005,10 @@
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000772">
         <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
         <domain:DRAO_0000001 xml:lang="en">Genomic island</domain:DRAO_0000001>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000839">
+        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
+        <domain:DRAO_0000001 xml:lang="en">Amino acid sequence</domain:DRAO_0000001>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000857">
         <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>

--- a/development/DRAO-manual.owl
+++ b/development/DRAO-manual.owl
@@ -238,6 +238,14 @@
     
 
 
+    <!-- http://purl.obolibrary.org/obo/SO_0000839 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000839">
+        <obo:IAO_0000118 xml:lang="en">Protein sequence</obo:IAO_0000118>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/SO_0001877 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0001877">

--- a/development/DRAO-merged.owl
+++ b/development/DRAO-merged.owl
@@ -948,19 +948,6 @@ Licensed under the Creative Commons Attribution 4.0 International (CC BY 4.0), h
     
 
 
-    <!-- http://edamontology.org/data_2044 -->
-
-    <owl:Class rdf:about="http://edamontology.org/data_2044">
-        <rdfs:subClassOf rdf:resource="http://edamontology.org/data_0006"/>
-        <obo:IAO_0000115>One or more molecular sequences, possibly with associated annotation.</obo:IAO_0000115>
-        <obo:IAO_0000118>Sequences</obo:IAO_0000118>
-        <obo:IAO_0000412 rdf:resource="http://edamontology.org/EDAM.owl"/>
-        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
-        <rdfs:label>Sequence</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://edamontology.org/data_2048 -->
 
     <owl:Class rdf:about="http://edamontology.org/data_2048">
@@ -1238,24 +1225,10 @@ Licensed under the Creative Commons Attribution 4.0 International (CC BY 4.0), h
     
 
 
-    <!-- http://edamontology.org/data_2976 -->
-
-    <owl:Class rdf:about="http://edamontology.org/data_2976">
-        <rdfs:subClassOf rdf:resource="http://edamontology.org/data_2044"/>
-        <obo:IAO_0000115>One or more protein sequences, possibly with associated annotation.</obo:IAO_0000115>
-        <obo:IAO_0000118>Protein sequences</obo:IAO_0000118>
-        <obo:IAO_0000412 rdf:resource="http://edamontology.org/EDAM.owl"/>
-        <domain:DRAO_0000001 xml:lang="en">Amino acid sequence</domain:DRAO_0000001>
-        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
-        <rdfs:label>Protein sequence</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://edamontology.org/data_2977 -->
 
     <owl:Class rdf:about="http://edamontology.org/data_2977">
-        <rdfs:subClassOf rdf:resource="http://edamontology.org/data_2044"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001411"/>
         <obo:IAO_0000115>One or more nucleic acid sequences, possibly with associated annotation.</obo:IAO_0000115>
         <obo:IAO_0000118>DNA sequence</obo:IAO_0000118>
         <obo:IAO_0000118>Nucleic acid sequences</obo:IAO_0000118>
@@ -10314,7 +10287,7 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OGMS_0000123">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000027"/>
-        <obo:IAO_0000115>a data item that is about a patient and is the specified output of a health care process assay or diagnostic process</obo:IAO_0000115>
+        <obo:IAO_0000115>A data item that is about a patient and is the specified output of a health care process assay or diagnostic process</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ogms.owl"/>
         <rdfs:label xml:lang="en">clinical data item</rdfs:label>
     </owl:Class>
@@ -10881,7 +10854,8 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
         <obo:IAO_0000115>A sequence_feature with an extent greater than zero. A nucleotide region is composed of bases and a polypeptide region is composed of amino acids.</obo:IAO_0000115>
         <obo:IAO_0000118>sequence</obo:IAO_0000118>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/so.owl"/>
-        <rdfs:label>region</rdfs:label>
+        <domain:DRAO_0000001 xml:lang="en">Sequence</domain:DRAO_0000001>
+        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
     </owl:Class>
     
 
@@ -11670,9 +11644,12 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/SO_0000839">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/SO_0001411"/>
         <obo:IAO_0000115>Biological sequence region that can be assigned to a specific subsequence of a polypeptide.</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">Protein sequence</obo:IAO_0000118>
         <obo:IAO_0000118>region</obo:IAO_0000118>
         <obo:IAO_0000118>site</obo:IAO_0000118>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/so.owl"/>
+        <domain:DRAO_0000001 xml:lang="en">Amino acid sequence</domain:DRAO_0000001>
+        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
         <rdfs:label>polypeptide_region</rdfs:label>
     </owl:Class>
     
@@ -13470,52 +13447,6 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
 
     <owl:NamedIndividual rdf:about="http://purl.obolibrary.org/obo/IDOMAL_0000786"/>
     <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-<<<<<<< HEAD
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
-=======
->>>>>>> master
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-<<<<<<< HEAD
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
-=======
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
->>>>>>> master
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-<<<<<<< HEAD
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-=======
->>>>>>> master
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
-    </rdf:Description>
-    <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
     </rdf:Description>
     <rdf:Description>
@@ -13525,31 +13456,10 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </rdf:Description>
     <rdf:Description>
-<<<<<<< HEAD
-=======
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
->>>>>>> master
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ogi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
     </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ogi.owl"/>
@@ -13561,25 +13471,67 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </rdf:Description>
     <rdf:Description>
-<<<<<<< HEAD
-=======
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </rdf:Description>
     <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
     </rdf:Description>
     <rdf:Description>
->>>>>>> master
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
-    </rdf:Description>
-    <rdf:Description>
-        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ogi.owl"/>
     </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ogi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ido.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/clo.owl"/>
+    </rdf:Description>
+    <rdf:Description>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
     </rdf:Description>
     <rdf:Description>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
@@ -13602,8 +13554,8 @@ has_function some GO:0003824 (catalytic activity)</obo:IAO_0000115>
         <obo:IAO_0000118>GPI anchor</obo:IAO_0000118>
         <domain:DRAO_0000001 xml:lang="en">Glycosylphosphatidylinositol anchor</domain:DRAO_0000001>
         <obo:IAO_0000118>GPI-anchor</obo:IAO_0000118>
-        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
         <rdfs:label>glycosylphosphatidylinositol anchor</rdfs:label>
+        <oboInOwl:inSubset xml:lang="en">FAIRsharing</oboInOwl:inSubset>
         <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/idomal.owl"/>
         <obo:IAO_0000115>They are glycolipids with the major function of anchoring proteins to cell membrane surfaces. They are particularly abundant in protozoan parasites, where they serve as the predominant mechanism for integrating glycoproteins and phosphosaccharides into membrane lipid bilayers.</obo:IAO_0000115>
     </rdf:Description>

--- a/development/DRAO-ontofox-annotation.txt
+++ b/development/DRAO-ontofox-annotation.txt
@@ -484,7 +484,6 @@ http://edamontology.org/data_1712 # Chemical structure image
 http://edamontology.org/data_1743 # Atomic coordinate
 http://edamontology.org/data_1872 # Taxonomic classification
 http://edamontology.org/data_2042 # Evidence
-http://edamontology.org/data_2044 # Sequence
 http://edamontology.org/data_2048 # Report
 http://edamontology.org/data_2140 # Concentration
 http://edamontology.org/data_2299 # Gene name
@@ -495,8 +494,6 @@ http://edamontology.org/data_2717 # Oligonucleotide probe annotation
 http://edamontology.org/data_2849 # Abstract
 http://edamontology.org/data_2851 # Drug structure
 http://edamontology.org/data_2899 # Drug name
-http://edamontology.org/data_2976 # Amino acid sequence
-http://edamontology.org/data_2976 # Protein sequence
 http://edamontology.org/data_2977 # Nucleic acid sequence
 http://edamontology.org/data_2978 # Reaction data
 http://edamontology.org/data_2979 # Peptide property
@@ -506,7 +503,6 @@ http://edamontology.org/data_3110 # Raw microarray data
 http://edamontology.org/data_3113 # Biological sample annotation
 http://edamontology.org/data_3153 # Protein image
 http://edamontology.org/data_3241 # Kinetic model
-http://edamontology.org/data_3494 # DNA sequence data
 http://edamontology.org/data_3494 # DNA sequence
 http://edamontology.org/data_3495 # RNA sequence
 http://edamontology.org/data_3505 # Bibliography
@@ -569,18 +565,14 @@ http://edamontology.org/operation_0004 # operation
 subClassOf http://purl.obolibrary.org/obo/OBI_0200000 # data transformation
 http://edamontology.org/data_0883 # Molecular structure
 subClassOf http://purl.obolibrary.org/obo/PATO_0000141 # Structure
-http://edamontology.org/topic_3383 # Biological imaging
-subClassOf http://purl.obolibrary.org/obo/ERO_0001312 # Imaging
-http://edamontology.org/topic_3384 # Medical imaging
-subClassOf http://purl.obolibrary.org/obo/ERO_0001312 # Imaging
-http://edamontology.org/topic_3345 # Data identity and mapping
-subClassOf http://purl.obolibrary.org/obo/ERO_0001218 # Data management
 http://edamontology.org/data_0942 # 2D PAGE image
 subClassOf http://purl.obolibrary.org/obo/IAO_0000101 # Image
 http://edamontology.org/data_1712 # Chemical structure image
 subClassOf http://purl.obolibrary.org/obo/IAO_0000101 # Image
 http://edamontology.org/data_3153 # Protein image
 subClassOf http://purl.obolibrary.org/obo/IAO_0000101 # Image
+http://edamontology.org/data_2977 # Nucleic acid sequence
+subClassOf http://purl.obolibrary.org/obo/SO_0001411 # biological_region
 
 ##
 ## Moving Topics out of the Topic hierarchy for cleaner hierarchies
@@ -605,6 +597,12 @@ http://edamontology.org/topic_0157 # Sequence composition, complexity and repeat
 subClassOf http://purl.obolibrary.org/obo/SO_0000400 # sequence_attribute
 http://edamontology.org/topic_3077 # Data acquisition
 subClassOf http://purl.obolibrary.org/obo/OBI_0000011 # planned process
+http://edamontology.org/topic_3383 # Biological imaging
+subClassOf http://purl.obolibrary.org/obo/ERO_0001312 # Imaging
+http://edamontology.org/topic_3384 # Medical imaging
+subClassOf http://purl.obolibrary.org/obo/ERO_0001312 # Imaging
+http://edamontology.org/topic_3345 # Data identity and mapping
+subClassOf http://purl.obolibrary.org/obo/ERO_0001218 # Data management
 
 [Source term retrieval setting]
 includeComputedIntermediates
@@ -2194,6 +2192,7 @@ mapTo http://purl.obolibrary.org/obo/IAO_0000118
 SO
 
 [Low level source term URIs]
+http://purl.obolibrary.org/obo/SO_0000001 # Sequence (SO name is 'region')
 http://purl.obolibrary.org/obo/SO_0000101 # Transposable element
 http://purl.obolibrary.org/obo/SO_0000110 # Sequence feature
 http://purl.obolibrary.org/obo/SO_0000112 # Primer

--- a/development/filter-labels.txt
+++ b/development/filter-labels.txt
@@ -1,1 +1,2 @@
 http://edamontology.org/data_3113
+http://purl.obolibrary.org/obo/SO_0000001

--- a/development/refactored-IRIs-current.txt
+++ b/development/refactored-IRIs-current.txt
@@ -1,6 +1,8 @@
 # List of refactored IRIs that have remained in DRAO.
 
 Old IRI|New IRI
+http://edamontology.org/data_2044|http://purl.obolibrary.org/obo/SO_0000001|Note: we are changing Sequence from EDAM to SO
+http://edamontology.org/data_2976|http://purl.obolibrary.org/obo/SO_0000839|Note: we are changing Amino acid sequence from EDAM to SO
 
 # List of promotions from user-defined tags to DRAO
 Old Label|New IRI

--- a/development/sparql/fsannotation.ru
+++ b/development/sparql/fsannotation.ru
@@ -201,7 +201,6 @@ INSERT {
   edam:data_1743 obo:inSubset "FAIRsharing"@en .
   edam:data_1872 obo:inSubset "FAIRsharing"@en .
   edam:data_2042 obo:inSubset "FAIRsharing"@en .
-  edam:data_2044 obo:inSubset "FAIRsharing"@en .
   edam:data_2048 obo:inSubset "FAIRsharing"@en .
   edam:data_2140 obo:inSubset "FAIRsharing"@en .
   edam:data_2299 obo:inSubset "FAIRsharing"@en .
@@ -213,8 +212,6 @@ INSERT {
   edam:data_2849 obo:inSubset "FAIRsharing"@en .
   edam:data_2851 obo:inSubset "FAIRsharing"@en .
   edam:data_2899 obo:inSubset "FAIRsharing"@en .
-  edam:data_2976 obo:inSubset "FAIRsharing"@en .
-  edam:data_2976 drao:DRAO_0000001 "Amino acid sequence"@en .
   edam:data_2977 obo:inSubset "FAIRsharing"@en .
   edam:data_2978 obo:inSubset "FAIRsharing"@en .
   edam:data_2979 obo:inSubset "FAIRsharing"@en .
@@ -1022,6 +1019,8 @@ INSERT {
   semsci:SIO_010423 drao:DRAO_0000001 "Target"@en .
 
   ## SO
+  obolib:SO_0000001	obo:inSubset "FAIRsharing"@en .
+  obolib:SO_0000001	drao:DRAO_0000001 "Sequence"@en .
   obolib:SO_0000101	obo:inSubset "FAIRsharing"@en .
   obolib:SO_0000101	drao:DRAO_0000001 "Transposable element"@en .
   obolib:SO_0000110	obo:inSubset "FAIRsharing"@en .
@@ -1106,6 +1105,8 @@ INSERT {
   obolib:SO_0000771 drao:DRAO_0000001 "Quantitative trait loci"@en .
   obolib:SO_0000772 obo:inSubset "FAIRsharing"@en .
   obolib:SO_0000772 drao:DRAO_0000001 "Genomic island"@en .
+  obolib:SO_0000839 obo:inSubset "FAIRsharing"@en .
+  obolib:SO_0000839 drao:DRAO_0000001 "Amino acid sequence"@en .
   obolib:SO_0000857 obo:inSubset "FAIRsharing"@en .
   obolib:SO_0000857 drao:DRAO_0000001 "Homologous"@en .
   obolib:SO_0000858 obo:inSubset "FAIRsharing"@en .


### PR DESCRIPTION
**Note 1: _clinical data item_ shows up in the diff below, though I didn't change it. This has come from an update of the external reference ontology, and has been updated in DRAO via Ontofox.**

**Note 2: the IAO annotation property _alternative term_ has various labels, some of which are in other languages (see image below). It seems that the Robot diff has picked up one of these other language labels to use instead of the English _alternative term_, but please note that there is no error in the way the OWL file is written. **
![altterm](https://user-images.githubusercontent.com/143586/89337428-d11b0680-d692-11ea-9df2-4dfbbfc9b269.png)


I have updated the `development/refactored-IRIs-current.txt` file with the following additions:

```
# List of refactored IRIs that have remained in DRAO.

Old IRI|New IRI
http://edamontology.org/data_2044|http://purl.obolibrary.org/obo/SO_0000001|Note: we are changing Sequence from EDAM to SO
http://edamontology.org/data_2976|http://purl.obolibrary.org/obo/SO_0000839|Note: we are changing Amino acid sequence from EDAM to SO

```

The following changes have been made, as compared by Robot diff on the master and branch version of `DRAO-merged.owl`:

# Ontology comparison

## Old
- Ontology IRI: `http://www.fairsharing.org/ontology/domain/DRAO.owl`
- Version IRI: *None*
- Loaded from: `file:/home/.../domain-ontology/development/build/DRAO-merged.owl`

## New
- Ontology IRI: `http://www.fairsharing.org/ontology/domain/DRAO.owl`
- Version IRI: *None*
- Loaded from: `file:/.../DRAO-merged-new.owl`

### Ontology imports 



### Ontology annotations 



### Nucleic acid sequence `http://edamontology.org/data_2977`
#### Removed
- [Nucleic acid sequence](http://edamontology.org/data_2977) SubClassOf [Sequence](http://edamontology.org/data_2044) 

#### Added
- [Nucleic acid sequence](http://edamontology.org/data_2977) SubClassOf [polypeptide_region](http://purl.obolibrary.org/obo/SO_0000839) 


### Protein sequence `http://edamontology.org/data_2976`
#### Removed
- [Protein sequence](http://edamontology.org/data_2976) [label](http://www.w3.org/2000/01/rdf-schema#label) "Protein sequence" 

- [Protein sequence](http://edamontology.org/data_2976) [FAIRsharing alternative term](http://www.fairsharing.org/ontology/domain/DRAO_0000001) "Amino acid sequence"@en 

- [Protein sequence](http://edamontology.org/data_2976) [inSubset](http://www.geneontology.org/formats/oboInOwl#inSubset) "FAIRsharing"@en 

- [Protein sequence](http://edamontology.org/data_2976) [definition](http://purl.obolibrary.org/obo/IAO_0000115) "One or more protein sequences, possibly with associated annotation." 

- [Protein sequence](http://edamontology.org/data_2976) [imported from](http://purl.obolibrary.org/obo/IAO_0000412) [EDAM.owl](http://edamontology.org/EDAM.owl) 

- [Protein sequence](http://edamontology.org/data_2976) [替代术语](http://purl.obolibrary.org/obo/IAO_0000118) "Protein sequences" 

- Class: [Protein sequence](http://edamontology.org/data_2976) 

- [Protein sequence](http://edamontology.org/data_2976) SubClassOf [Sequence](http://edamontology.org/data_2044) 



### Sequence `http://edamontology.org/data_2044`
#### Removed
- [Sequence](http://edamontology.org/data_2044) [imported from](http://purl.obolibrary.org/obo/IAO_0000412) [EDAM.owl](http://edamontology.org/EDAM.owl) 

- [Sequence](http://edamontology.org/data_2044) [label](http://www.w3.org/2000/01/rdf-schema#label) "Sequence" 

- [Sequence](http://edamontology.org/data_2044) [inSubset](http://www.geneontology.org/formats/oboInOwl#inSubset) "FAIRsharing"@en 

- [Sequence](http://edamontology.org/data_2044) [替代术语](http://purl.obolibrary.org/obo/IAO_0000118) "Sequences" 

- [Sequence](http://edamontology.org/data_2044) [definition](http://purl.obolibrary.org/obo/IAO_0000115) "One or more molecular sequences, possibly with associated annotation." 

- Class: [Sequence](http://edamontology.org/data_2044) 

- [Sequence](http://edamontology.org/data_2044) SubClassOf [Data](http://edamontology.org/data_0006) 



### clinical data item `http://purl.obolibrary.org/obo/OGMS_0000123`
#### Removed
- [clinical data item](http://purl.obolibrary.org/obo/OGMS_0000123) [definition](http://purl.obolibrary.org/obo/IAO_0000115) "a data item that is about a patient and is the specified output of a health care process assay or diagnostic process" 

#### Added
- [clinical data item](http://purl.obolibrary.org/obo/OGMS_0000123) [definition](http://purl.obolibrary.org/obo/IAO_0000115) "A data item that is about a patient and is the specified output of a health care process assay or diagnostic process" 


### polypeptide_region `http://purl.obolibrary.org/obo/SO_0000839`

#### Added
- [polypeptide_region](http://purl.obolibrary.org/obo/SO_0000839) [inSubset](http://www.geneontology.org/formats/oboInOwl#inSubset) "FAIRsharing"@en 

- [polypeptide_region](http://purl.obolibrary.org/obo/SO_0000839) [FAIRsharing alternative term](http://www.fairsharing.org/ontology/domain/DRAO_0000001) "Amino acid sequence"@en 

- [polypeptide_region](http://purl.obolibrary.org/obo/SO_0000839) [替代术语](http://purl.obolibrary.org/obo/IAO_0000118) "Protein sequence"@en 


### region `http://purl.obolibrary.org/obo/SO_0000001`
#### Removed
- [region](http://purl.obolibrary.org/obo/SO_0000001) [label](http://www.w3.org/2000/01/rdf-schema#label) "region" 

#### Added
- [region](http://purl.obolibrary.org/obo/SO_0000001) [inSubset](http://www.geneontology.org/formats/oboInOwl#inSubset) "FAIRsharing"@en 

- [region](http://purl.obolibrary.org/obo/SO_0000001) [FAIRsharing alternative term](http://www.fairsharing.org/ontology/domain/DRAO_0000001) "Sequence"@en 